### PR TITLE
Extend Standard JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,3 @@ Once the `eslint-config-nava` package is installed, you can use it by specifying
   }
 }
 ```
-
-### Using the `nava` config with `eslint:recommended`
-
-It's suggested to use the `nava` ruleset alongside the [`eslint:recommended` ruleset](http://eslint.org/docs/rules/).
-
-To use in conjunction with ESLint's recommended rule set, extend them both, making sure to list `nava` last:
-
-```js
-{
-  "extends": ["eslint:recommended", "nava"],
-  "rules": {
-    // Additional, per-project rules...
-  }
-}
-```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 > ESLint [shareable config](http://eslint.org/docs/developer-guide/shareable-configs.html) for Navanauts and beyond.
 
+We're based on [Standard JS](http://standardjs.com/), which provides a complete node/browser/react ruleset, with a few changes:
+
+* using `eslint` directly, since we want to relax rulesets for adoption into existing repos
+* enforcing use of semicolons
+* locking to es6, as we don't assume babel compilation for node services
+
+See the full Standard JS ruleset here: https://github.com/feross/eslint-config-standard/blob/master/eslintrc.json
+and for Standard React: https://github.com/feross/eslint-config-standard-react/blob/master/eslintrc.json
 
 ## Installation
 
@@ -9,6 +17,10 @@ Note: This package isn't published to NPM yet, so you'll need to reference it by
 
 ```
 $ npm install --save-dev eslint navahq/eslint-config-nava
+```
+or
+```
+$ yarn add eslint navahq/eslint-config-nava --dev
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,5 @@
 module.exports = {
   extends: ['standard', 'standard-react'],
-  env: {
-    mocha: true
-  },
   parserOptions: {
     ecmaVersion: 6
   },

--- a/index.js
+++ b/index.js
@@ -1,26 +1,23 @@
 module.exports = {
-  'rules': {
-    'brace-style': [2, '1tbs'],
-    'comma-style': [2, 'last'],
-    'indent': [2, 2],
-    'quotes': [2, 'single'],
-    'linebreak-style': [2, 'unix'],
-    'no-alert': 'error',
-    'new-cap': [2, {
-      'newIsCapExceptions': ['baseError']
-    }],
-    'no-underscore-dangle': [0],
-    'no-unneeded-ternary': [0],
-    'no-unused-vars': [2, {
-      'args': 'none'
-    }],
-    'semi': [2, 'always'],
-    'sort-vars': [2, {
-      'ignoreCase': true
-    }],
-    'space-before-blocks': [2, 'always'],
-    'space-before-function-paren': [2, 'never'],
-    'space-in-parens': [2, 'never'],
-    'strict': [0],
+  extends: ['standard', 'standard-react'],
+  env: {
+    mocha: true
+  },
+  parserOptions: {
+    ecmaVersion: 6
+  },
+  rules: {
+    /*
+      Standard overrides
+    */
+    semi: ['error', 'always'], // churn-expensive to enforce
+    'space-before-function-paren': ['error', 'never'],
+
+    /*
+      Nava-specific rules
+    */
+    'linebreak-style': ['error', 'unix'],
+    'sort-vars': ['error', {ignoreCase: true}],
+    'no-alert': 'error'
   }
-}
+};

--- a/package.json
+++ b/package.json
@@ -15,9 +15,18 @@
     "index.js"
   ],
   "devDependencies": {
-    "eslint": "^3.8.1"
+    "eslint": "^3.17.1"
+  },
+  "dependencies": {
+    "eslint-config-standard": "7.0.1",
+    "eslint-config-standard-react": "4.3.0",
+    "eslint-plugin-import": "2.2.0",
+    "eslint-plugin-node": "4.2.1",
+    "eslint-plugin-promise": "3.5.0",
+    "eslint-plugin-react": "6.10.0",
+    "eslint-plugin-standard": "2.1.1"
   },
   "peerDependencies": {
-    "eslint": ">=3.8.1"
+    "eslint": ">=3.17.1"
   }
 }


### PR DESCRIPTION
[Standard JS](http://standardjs.com/) provides most almost all of the conventions we were encoding here (plus a whole bunch more) - this pull request changes eslint-config-nava to become an extension of Standard JS.

We extend rather than use Standard JS's executable directly because we need to be adoptable by existing projects, requiring extensible (relaxable) rules.

The biggest departure from Standard JS is to allow semicolons, since disallowing would incur tons of churn. We could optionally push this exception (and some others here) into each project or draw some line for old vs new projects, but this pull request as-is is a good representation of both where our code is now and a feasible path for getting to where we want to be without a lot of syntax/whitespace churn.