### PR TITLE
Add method for testing linting rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "./index.js"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,11 @@
 1. Commit your changes
 1. Make a pull request against the `master` branch
 
+### Testing
+
+- If you'd like to test linting rules, add or update the `.js` files in the `test` directory.
+- Then run `npm run lint`
+
 ## Release process
 
 1. Bump the version in `package.json`

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "license": "Apache-2.0",
   "repository": "navahq/eslint-config-nava",
   "author": "Nava PBC",
+  "scripts": {
+    "lint": "eslint ./test -f table"
+  },
   "engines": {
     "node": ">=4.0.0"
   },

--- a/test/example.js
+++ b/test/example.js
@@ -1,0 +1,16 @@
+var unusedVar = require("path");
+
+// Lint this file to test various linting rules
+console.log("Hello world");
+
+function testFunc(unusedArg) {
+  return Promise.resolve(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, 1000);
+  });
+}
+
+testFunc.then(() => {
+  console.log("Rejected promises aren't handled here.");
+});


### PR DESCRIPTION
This can be helpful when you want to confirm the linter runs with our configurations, as well as to check whether it outputs any deprecation warnings.

## Example

![image](https://user-images.githubusercontent.com/371943/61997661-d3578780-b072-11e9-9cdb-12ea30799d45.png)
