### PR TITLE
Allow usage of native ES6 Promise implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ module.exports = {
     'no-var': 'error',
     'prefer-const': 'error',
     'prefer-arrow-callback': 'error',
-    'promise/no-native': 'error',
     'promise/catch-or-return': 'error',
     'promise/no-return-wrap': 'error',
     'promise/valid-params': 'error'


### PR DESCRIPTION
This removes the enforcement of the `promise/no-native` rule, which would throw a lint error if a project used the platform's native `Promise` implementation. Promises are well supported at this point, with IE11 being an exception. For IE11 support, folks can use a polyfill.

## Browser support

![image](https://user-images.githubusercontent.com/371943/68334228-2d231100-00a8-11ea-9323-709b619a7508.png)

## Node support

![image](https://user-images.githubusercontent.com/371943/68334206-1ed4f500-00a8-11ea-8ccb-51f4d9c379e3.png)
