### PR TITLE
Deprecate the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # eslint-config-nava
 
+> [!IMPORTANT] > **This package is no longer maintained.** We recommend using a layering of: Prettier for code formatting and `eslint:recommended` for basic JS linting, the linting config provided by your project's React framework ([Next.js](https://nextjs.org/docs/pages/building-your-application/configuring/eslint), [Remix](https://www.npmjs.com/package/@remix-run/eslint-config)), and [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint) if your project uses TypeScript.
+
+---
+
 > ESLint [shareable config](http://eslint.org/docs/developer-guide/shareable-configs.html) for Navanauts and beyond.
 
 We're based on [Standard JS](http://standardjs.com/), which provides a complete node/browser/react ruleset, with a few changes:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # eslint-config-nava
 
-> [!IMPORTANT] > **This package is no longer maintained.** We recommend using a layering of: Prettier for code formatting and `eslint:recommended` for basic JS linting, the linting config provided by your project's React framework ([Next.js](https://nextjs.org/docs/pages/building-your-application/configuring/eslint), [Remix](https://www.npmjs.com/package/@remix-run/eslint-config)), and [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint) if your project uses TypeScript.
+> [!IMPORTANT] 
+> **This package is no longer maintained.** We recommend using a layering of: Prettier for code formatting and `eslint:recommended` for basic JS linting, the linting config provided by your project's React framework ([Next.js](https://nextjs.org/docs/pages/building-your-application/configuring/eslint), [Remix](https://www.npmjs.com/package/@remix-run/eslint-config)), and [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint) if your project uses TypeScript.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # eslint-config-nava
 
 > [!IMPORTANT] 
-> **This package is no longer maintained.** We recommend using a layering of: Prettier for code formatting and `eslint:recommended` for basic JS linting, the linting config provided by your project's React framework ([Next.js](https://nextjs.org/docs/pages/building-your-application/configuring/eslint), [Remix](https://www.npmjs.com/package/@remix-run/eslint-config)), and [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint) if your project uses TypeScript.
+> **This package is no longer maintained.** We recommend using a layering of: Prettier for code formatting, [`eslint:recommended`](https://eslint.org/docs/latest/use/configure/configuration-files#extending-configuration-files) for basic JS linting, the linting config provided by your project's React framework ([Next.js](https://nextjs.org/docs/pages/building-your-application/configuring/eslint), [Remix](https://www.npmjs.com/package/@remix-run/eslint-config)), and [`typescript-eslint`](https://github.com/typescript-eslint/typescript-eslint) if your project uses TypeScript.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # eslint-config-nava
 
 > [!IMPORTANT] 
-> **This package is no longer maintained.** We recommend using a layering of: Prettier for code formatting, [`eslint:recommended`](https://eslint.org/docs/latest/use/configure/configuration-files#extending-configuration-files) for basic JS linting, the linting config provided by your project's React framework ([Next.js](https://nextjs.org/docs/pages/building-your-application/configuring/eslint), [Remix](https://www.npmjs.com/package/@remix-run/eslint-config)), and [`typescript-eslint`](https://github.com/typescript-eslint/typescript-eslint) if your project uses TypeScript.
+> **This package is no longer maintained.** We recommend using a layering of: Prettier for code formatting, [`eslint:recommended`](https://eslint.org/docs/latest/use/configure/configuration-files#extending-configuration-files) for basic JS linting, the linting config provided by your project's React framework ([Next.js](https://nextjs.org/docs/pages/building-your-application/configuring/eslint), [Remix](https://www.npmjs.com/package/@remix-run/eslint-config)), and [`typescript-eslint`](https://github.com/typescript-eslint/typescript-eslint) if your project uses TypeScript. You can [reference Nava's Next.js template for an example](https://github.com/navapbc/template-application-nextjs).
 
 ---
 


### PR DESCRIPTION
## Context

We created this package over 5 years ago as a way to share JS standards and best practices across Nava projects, mostly by utilizing [Standard JS](https://standardjs.com/) and extending a few React plugins. Since then, the JS ecosystem has matured a lot: Prettier is the defacto standard for code formatting, and robust React frameworks like Next.js and Remix have begun providing their own linting configs that do a better job of enforcing best practices for their respective frameworks. Nava also now maintains an entire template, which includes an example linting setup. 

Maintaining this package has always been somewhat spotty, with only one or two people sometimes updating its dependencies. Awareness of the package is also not great. 

Given all of this, I don't think it's worth continued time investment in maintaining this library, and projects should instead use the linting configs already provided by the open source communities around their respective frameworks and languages, and/or reference the [Nava template](https://github.com/navapbc/template-application-nextjs).

A corresponding Platform template PR removing this package can be found here: https://github.com/navapbc/template-application-nextjs/pull/196

## Screenshot of this markdown

<img width="971" alt="CleanShot 2023-08-16 at 17 35 56@2x" src="https://github.com/navapbc/eslint-config-nava/assets/371943/e98fff22-3bea-45de-98a8-2a6c3225edea">
